### PR TITLE
Add secret description and integration into springboot application

### DIFF
--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -196,7 +196,7 @@ Die Konfiguration kann auch in der Web Console angeschaut und verändert werden:
 
 (Applications → Deployments → example-spring-boot, Actions, Edit YAML)
 
-## Aufgabe: LAB8.2.1: Setzen der Werte für Usernamen und Passwort aus dem Secret mysql
+## Aufgabe: LAB8.2.1: Secret referenzieren
 
 Weiter oben haben wir gesehen, wie OpenShift mittels Secrets senisitive Informationen von der eigentlichen Konfiguration enkoppelt und uns dabei hilft Redundanzen zu vermeiden. Unsere Springboot Applikation aus dem vorherigen Lab haben wir zwar korrekt konfiguriert, allerings aber die Werte redundant und plaintext in der DeploymentConfig abgelegt.
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -116,7 +116,7 @@ anzeigen lassen. In userem Fall wird `YXBwdWlv` in `appuio` dekodiert.
 
 Mit Secrets können wir also sensitive Informationen (Credetials, Zertifikate, Schlüssel, dockercfg, ...) abspeichern und entsprechend von den Pods entkoppeln. Gleichzeitig haben wir damit die Möglichkeit, dieselben Secrets in mehreren Containern zu verwenden und so Redundanzen zu vermeiden.
 
-Secrets können entweder wie oben bei der mysql Datenbank in Umgebungsvaribablen gemappt oder direkt als Files via volumes in einen Container gemounted werden.
+Secrets können entweder, wie oben bei der MySQL-Datenbank, in Umgebungsvariablen gemappt oder direkt als Files via Volumes in einen Container gemountet werden.
 
 Weitere Informationen zu Secrets können hier gefunden werden: https://docs.openshift.com/container-platform/3.9/dev_guide/secrets.html
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-Die konkreten Werte sind mittels base64 enkodiert. Unter Linux oder in der Gitbash kann man sich den entsprechenden Wert einfach mittels:
+Die konkreten Werte sind base64-kodiert. Unter Linux oder in der Gitbash kann man sich den entsprechenden Wert einfach mittels:
 
 ```bash
 $ echo "YXBwdWlv" | base64 -d

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -74,7 +74,7 @@ Konkret geht es um die Konfiguration der Container mittels env (MYSQL_USER, MYSQ
 
 Die Werte für die einzelnen Umgebungsvariablen kommen also aus einem sogenannten Secret, in unserem Fall hier aus dem Secret mit Namen `mysql`. In diesem Secret sind die vier Werte entsprechend unter den passenden Keys (`database-user`, `database-password`, `database-root-password`, `database-name`) abgelegt und können so referenziert werden.
 
-Schauen wir uns nun die neue Resource Secret mit dem Namen `mysql` an:
+Schauen wir uns nun die neue Ressource Secret mit dem Namen `mysql` an:
 
 ```bash
 $ oc get secret mysql -o yaml

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -80,7 +80,7 @@ Schauen wir uns nun die neue Ressource Secret mit dem Namen `mysql` an:
 $ oc get secret mysql -o yaml
 ```
 
-Die entsprechenden Key-Value Pairs sind unter Data ersichtlich:
+Die entsprechenden Key-Value Pairs sind unter `data` ersichtlich:
 
 ```yaml
 apiVersion: v1

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -114,7 +114,7 @@ appuio
 ```
 anzeigen lassen. In userem Fall wird `YXBwdWlv` in `appuio` dekodiert.
 
-Mit Secrets können wir also sensitive Informationen(Credetials, Zertifikate, Schlüssel, dockercfg ...) abspeichern und entsprechend von den Pods entkoppeln. Gleichzeitig, haben wir damit die Möglichkeit, die selben Secrets in mehreren Container zu verwenden und so Redundanzen zu vermeiden.
+Mit Secrets können wir also sensitive Informationen (Credetials, Zertifikate, Schlüssel, dockercfg, ...) abspeichern und entsprechend von den Pods entkoppeln. Gleichzeitig haben wir damit die Möglichkeit, dieselben Secrets in mehreren Containern zu verwenden und so Redundanzen zu vermeiden.
 
 Secrets können entweder wie oben bei der mysql Datenbank in Umgebungsvaribablen gemappt oder direkt als Files via volumes in einen Container gemounted werden.
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -36,7 +36,7 @@ In der Web Console kann der MySQL (Ephemeral) Service via Catalog dem Projekt hi
 
 ### Passwort und Username als Plaintext?
 
-Beim Deployen der Datebank sowohl via CLI aber auch via Web Console, haben wir mittels Parameter oder direkt im Eingabefeld Werte für User, Passwort und Datenbank angegeben. In diesem Kapitel wollen wir uns nun anschauen, wo diese sensitiven Daten nun effektiv gelandet sind.
+Beim Deployen der Datebank via CLI wie auch via Web Console haben wir mittels Parameter Werte für User, Passwort und Datenbank angegeben. In diesem Kapitel wollen wir uns nun anschauen, wo diese sensitiven Daten effektiv gelandet sind.
 
 Schauen wir uns als erstes die DeploymentConfig der Datenbank an:
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -198,7 +198,7 @@ Die Konfiguration kann auch in der Web Console angeschaut und verändert werden:
 
 ## Aufgabe: LAB8.2.1: Secret referenzieren
 
-Weiter oben haben wir gesehen, wie OpenShift mittels Secrets senisitive Informationen von der eigentlichen Konfiguration enkoppelt und uns dabei hilft Redundanzen zu vermeiden. Unsere Springboot Applikation aus dem vorherigen Lab haben wir zwar korrekt konfiguriert, allerings aber die Werte redundant und plaintext in der DeploymentConfig abgelegt.
+Weiter oben haben wir gesehen, wie OpenShift mittels Secrets sensitive Informationen von der eigentlichen Konfiguration enkoppelt und uns dabei hilft, Redundanzen zu vermeiden. Unsere Springboot Applikation aus dem vorherigen Lab haben wir zwar korrekt konfiguriert, allerings aber die Werte redundant und Plaintext in der DeploymentConfig abgelegt.
 
 Passen wir nun die DeploymentConfig example-spring-boot so an, dass die Werte aus den Secrets verwendet werden. Zu beachten gibt es die Konfiguration der Container unter `spec.template.spec.containers`
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -118,7 +118,7 @@ Mit Secrets können wir also sensitive Informationen (Credetials, Zertifikate, S
 
 Secrets können entweder, wie oben bei der MySQL-Datenbank, in Umgebungsvariablen gemappt oder direkt als Files via Volumes in einen Container gemountet werden.
 
-Weitere Informationen zu Secrets können hier gefunden werden: https://docs.openshift.com/container-platform/3.9/dev_guide/secrets.html
+Weitere Informationen zu Secrets können in der [offiziellen Dokumentation](https://docs.openshift.com/container-platform/3.9/dev_guide/secrets.html) gefunden werden.
 
 ## Aufgabe: LAB8.2: Applikation an die Datenbank anbinden
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -34,7 +34,7 @@ In der Web Console kann der MySQL (Ephemeral) Service via Catalog dem Projekt hi
 
 ![MySQLService](../images/lab_8_mysql.png)
 
-### Passwort und Username als plaintext?
+### Passwort und Username als Plaintext?
 
 Beim Deployen der Datebank sowohl via CLI aber auch via Web Console, haben wir mittels Parameter oder direkt im Eingabefeld Werte für User, Passwort und Datenbank angegeben. In diesem Kapitel wollen wir uns nun anschauen, wo diese sensitiven Daten nun effektiv gelandet sind.
 

--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -72,7 +72,7 @@ Konkret geht es um die Konfiguration der Container mittels env (MYSQL_USER, MYSQ
               name: mysql
 ```
 
-Die Werte für die einzelnen Umgebungsvariablen kommen also aus einem sogenannten Secret, in unserem Fall hier aus dem Secret mit dem Namen `mysql`. In diesem Secret sind die vier Werte entsprechend unter den passenden Keys (`database-user`, `database-password`, `database-root-password`, `database-name`) abgelegt und können ebenso darauf zu gegriffen werden.
+Die Werte für die einzelnen Umgebungsvariablen kommen also aus einem sogenannten Secret, in unserem Fall hier aus dem Secret mit Namen `mysql`. In diesem Secret sind die vier Werte entsprechend unter den passenden Keys (`database-user`, `database-password`, `database-root-password`, `database-name`) abgelegt und können so referenziert werden.
 
 Schauen wir uns nun die neue Resource Secret mit dem Namen `mysql` an:
 


### PR DESCRIPTION
Updates the Lab 8 and describes how Secrets can be used and integrated into both pods, mysql and springboot.

fixes #36 