### PR TITLE
added missing database name YXBwdWlv (base64 encoded) to yaml response

### DIFF
--- a/labs/08_database.md
+++ b/labs/08_database.md
@@ -85,7 +85,7 @@ Die entsprechenden Key-Value Pairs sind unter `data` ersichtlich:
 ```yaml
 apiVersion: v1
 data:
-  database-name: 
+  database-name: YXBwdWlv
   database-password: YXBwdWlv
   database-root-password: dDB3ZDFLRFhsVjhKMGFHQw==
   database-user: YXBwdWlv


### PR DESCRIPTION
Hi, I spotted this difference in the techlab today.