### PR TITLE
Change 4.3 to 'latest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # APPUiO - OpenShift 4 Techlab
 
-Dieses Techlab basiert auf OpenShift 4.3.
+Dieses Techlab basiert auf OpenShift 4.
 
 ## Einführung
 
@@ -37,7 +37,7 @@ __Ziele dieses Techlabs__:
 
 ## Weiterführende Dokumentation
 
-- [OpenShift Container Platform 4.3 Dokumentation](https://docs.openshift.com/container-platform/4.3/welcome/index.html)
+- [OpenShift Container Platform 4 Dokumentation](https://docs.openshift.com/container-platform/latest/welcome/index.html)
 - [APPUiO Dokumentation](http://docs.appuio.ch)
 
 ### APPUiO Examples

--- a/additional-labs/cronjobs_and_jobs.md
+++ b/additional-labs/cronjobs_and_jobs.md
@@ -20,13 +20,13 @@ Wird ein Job gelöscht, werden auch die vom Job gestarteten (und wieder beendete
 Ein Job eignet sich also bspw. dafür, sicherzustellen, dass ein Pod verlässlich bis zu dessen Vervollständigung ausgeführt wird.
 Schlägt ein Pod fehl, zum Beispiel wegen eines Node-Fehlers, startet der Job einen neuen Pod.
 
-Weitere Informationen zu Jobs sind in der [OpenShift Dokumentation](https://docs.openshift.com/container-platform/4.3/nodes/jobs/nodes-nodes-jobs.html) zu finden.
+Weitere Informationen zu Jobs sind in der [OpenShift Dokumentation](https://docs.openshift.com/container-platform/latest/nodes/jobs/nodes-nodes-jobs.html) zu finden.
 
 ## Cron Jobs
 
 Ein OpenShift Cron Job ist nichts anderes als eine Ressource, welche zu definierten Zeitpunkten einen Job erstellt, welcher wiederum wie gewohnt einen Pod startet um einen Befehl auszuführen.
 
-Weitere Informationen zu Cron Jobs sind auf derselben [OpenShift Dokumentationsseite](https://docs.openshift.com/container-platform/4.3/nodes/jobs/nodes-nodes-jobs.html) zu finden wie die Jobs.
+Weitere Informationen zu Cron Jobs sind auf derselben [OpenShift Dokumentationsseite](https://docs.openshift.com/container-platform/latest/nodes/jobs/nodes-nodes-jobs.html) zu finden wie die Jobs.
 
 ## Aufgabe: Job für MariaDB-Dump erstellen
 

--- a/labs/02_cli.md
+++ b/labs/02_cli.md
@@ -10,13 +10,13 @@ Der __oc client__ stellt ein Interface zu OpenShift bereit.
 
 ### Installation
 
-Gemäss [offizieller Dokumentation](https://docs.openshift.com/container-platform/4.3/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands) kann der __oc client__ von der __Infrastructure Provider__ Seite heruntergeladen werden, oder einfacher gleich direkt von folgender URL: <https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/>
+Gemäss [offizieller Dokumentation](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-installing-cli_cli-developer-commands) kann der __oc client__ von der __Infrastructure Provider__ Seite heruntergeladen werden, oder einfacher gleich direkt von folgender URL: <https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/>
 
 __Tipp__:
 Alternativ kann die Binary auch mittels folgenden Befehlen im Terminal installiert werden:
 
 ```
-curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/linux/oc.tar.gz | sudo tar xfz - -C /usr/bin
+curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz | sudo tar xfz - -C /usr/bin
 ```
 
 
@@ -24,7 +24,7 @@ curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.3/linux/oc
 
 Dieser Schritt ist optional und funktioniert nicht auf Windows. Damit Command Completion auf macOS funktioniert, muss bspw. via `brew` das Paket `bash-completion` installiert werden.
 
-`oc` bietet eine Command Completion, die gem. [Dokumention](https://docs.openshift.com/container-platform/4.3/cli_reference/openshift_cli/configuring-cli.html#cli-enabling-tab-completion_cli-configuring-cli) eingerichtet werden kann.
+`oc` bietet eine Command Completion, die gem. [Dokumention](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/configuring-cli.html#cli-enabling-tab-completion_cli-configuring-cli) eingerichtet werden kann.
 
 __Tipp__:
 Alternativ kann die Bash Command Completion auch mittels folgenden Befehlen im Terminal installiert werden:

--- a/labs/03_first_steps.md
+++ b/labs/03_first_steps.md
@@ -76,7 +76,7 @@ Die OpenShift Web Console erlaubt es den Benutzern gewisse Tasks direkt via Brow
 
 1. Belassen Sie die restlichen Felder leer oder auf deren Standardwert und klicken auf _Create_
 
-Sie haben soeben Ihre erste Applikation mittels sog. __[Source to Image](https://docs.openshift.com/container-platform/4.3/builds/build-strategies.html#build-strategy-s2i_build-strategies)__ Build auf OpenShift deployed.
+Sie haben soeben Ihre erste Applikation mittels sog. __[Source to Image](https://docs.openshift.com/container-platform/latest/builds/build-strategies.html#build-strategy-s2i_build-strategies)__ Build auf OpenShift deployed.
 
 __Tipp__:
 Mit den folgenden Befehlen kann das obere Beispiel auf der Kommandozeile erstellt werden:

--- a/labs/04_deploy_dockerimage.md
+++ b/labs/04_deploy_dockerimage.md
@@ -52,7 +52,7 @@ In der Zwischenzeit können Sie sich in der Web Console den aktuellen Status des
 
 __Tipp__:
 Um Ihre eigenen Container Images für OpenShift zu erstellen, sollten Sie die folgenden Best Practices befolgen:
-<https://docs.openshift.com/container-platform/4.3/openshift_images/create-images.html>
+<https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html>
 
 
 ## Betrachten der erstellten Ressourcen
@@ -61,8 +61,8 @@ Als wir vorhin `oc new-app appuio/example-spring-boot` ausführten, hat OpenShif
 Diese werden dafür benötigt, das Container Image zu deployen:
 
 - Service
-- [ImageStream](https://docs.openshift.com/container-platform/4.3/openshift_images/images-understand.html)
-- [DeploymentConfig](https://docs.openshift.com/container-platform/4.3/applications/deployments/what-deployments-are.html)
+- [ImageStream](https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html)
+- [DeploymentConfig](https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html)
 
 
 ### Service
@@ -226,7 +226,7 @@ Unter Endpoints finden Sie nun den aktuell laufenden Pod.
 
 ### ImageStream
 
-[ImageStreams](https://docs.openshift.com/container-platform/4.3/openshift_images/image-streams-manage.html) werden dafür verwendet, automatische Tasks auszuführen wie bspw. ein Deployment zu aktualisieren, wenn eine neue Version des Image verfügbar ist.
+[ImageStreams](https://docs.openshift.com/container-platform/latest/openshift_images/image-streams-manage.html) werden dafür verwendet, automatische Tasks auszuführen wie bspw. ein Deployment zu aktualisieren, wenn eine neue Version des Image verfügbar ist.
 
 Builds und Deployments können ImageStreams beobachten und auf Änderungen reagieren.
 In unserem Beispiel wird der Image Stream dafür verwendet, ein Deployment zu triggern, sobald etwas am Image geändert hat.
@@ -240,7 +240,7 @@ oc get imagestream example-spring-boot -o json
 
 ### DeploymentConfig
 
-In der [DeploymentConfig](https://docs.openshift.com/container-platform/4.3/applications/deployments/what-deployments-are.html) werden folgende Punkte definiert:
+In der [DeploymentConfig](https://docs.openshift.com/container-platform/latest/applications/deployments/what-deployments-are.html) werden folgende Punkte definiert:
 
 - Update Strategy: Wie werden Applikationsupdates ausgeführt, wie erfolgt das Austauschen der Container?
 - Triggers: Welche Ereignisse führen zu einem automatischen Deployment?

--- a/labs/06_scale.md
+++ b/labs/06_scale.md
@@ -87,7 +87,7 @@ Events:            <none>
 Skalieren von Pods innerhalb eines Service ist sehr schnell, da OpenShift einfach eine neue Instanz des Container Images als Container startet.
 
 __Tipp__:
-OpenShift unterstützt auch [Autoscaling](https://docs.openshift.com/container-platform/4.3/nodes/pods/nodes-pods-autoscaling.html).
+OpenShift unterstützt auch [Autoscaling](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-autoscaling.html).
 
 
 ## Aufgabe 3: Skalierte App in der Web Console
@@ -187,10 +187,10 @@ Im folgenden Kapitel wird beschrieben, wie Sie Ihre Services konfigurieren könn
 
 ## Unterbruchsfreies Deployment dank Health Checks und Rolling Update
 
-Die "[Rolling Strategy](https://docs.openshift.com/container-platform/4.3/applications/deployments/deployment-strategies.html#deployments-rolling-strategy_deployment-strategies)" ermöglicht unterbruchsfreie Deployments.
+Die "[Rolling Strategy](https://docs.openshift.com/container-platform/latest/applications/deployments/deployment-strategies.html#deployments-rolling-strategy_deployment-strategies)" ermöglicht unterbruchsfreie Deployments.
 Damit wird die neue Version der Applikation gestartet, sobald die Applikation bereit ist, werden Requests auf den neuen Pod geleitet und die alte Version entfernt.
 
-Zusätzlich kann mittels [Container Health Checks](https://docs.openshift.com/container-platform/4.3/applications/application-health.html#application-health-configuring_application-health) die deployte Applikation der Plattform detailliertes Feedback über ihr aktuelles Befinden übermitteln.
+Zusätzlich kann mittels [Container Health Checks](https://docs.openshift.com/container-platform/latest/applications/application-health.html#application-health-configuring_application-health) die deployte Applikation der Plattform detailliertes Feedback über ihr aktuelles Befinden übermitteln.
 
 Grundsätzlich gibt es zwei Arten von Health Checks, die implementiert werden können:
 

--- a/labs/07_operators.md
+++ b/labs/07_operators.md
@@ -215,7 +215,7 @@ Mit `oc get pod` können wir nun verifizieren, dass der Operator Pod entfernt wu
 
 ## Weiterführende Informationen
 
-* [OpenShift Dokumentation zu Operators](https://docs.openshift.com/container-platform/4.3/operators/olm-what-operators-are.html)
+* [OpenShift Dokumentation zu Operators](https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html)
 * [Buch von O'Reilly über Operators](https://www.redhat.com/cms/managed-files/cl-oreilly-kubernetes-operators-ebook-f21452-202001-en_2.pdf)
 
 ---

--- a/labs/08_troubleshooting_ops.md
+++ b/labs/08_troubleshooting_ops.md
@@ -123,7 +123,7 @@ Die Metrics können nun unter folgender URL abgerufen werden: [http://localhost:
 Die Metrics werden Ihnen als JSON angezeigt.
 Mit demselben Konzept können Sie nun bspw. mit Ihrem lokalen SQL Client auf eine Datenbank verbinden.
 
-In der [Dokumentation](https://docs.openshift.com/container-platform/4.3/nodes/containers/nodes-containers-port-forwarding.html) sind weiterführende Informationen zu Port Forwarding zu finden.
+In der [Dokumentation](https://docs.openshift.com/container-platform/latest/nodes/containers/nodes-containers-port-forwarding.html) sind weiterführende Informationen zu Port Forwarding zu finden.
 
 __Note__:
 Der `oc port-forward`-Prozess wird solange weiterlaufen, bis er vom User abgebrochen wird.

--- a/labs/09_database.md
+++ b/labs/09_database.md
@@ -159,7 +159,7 @@ Gleichzeitig haben wir damit die Möglichkeit, dieselben Secrets in mehreren Con
 
 Secrets können entweder, wie oben bei der MariaDB-Datenbank, in Umgebungsvariablen gemappt oder direkt als Files via Volumes in einen Container gemountet werden.
 
-Weitere Informationen zu Secrets können in der [offiziellen Dokumentation](https://docs.openshift.com/container-platform/4.3/nodes/pods/nodes-pods-secrets.html) gefunden werden.
+Weitere Informationen zu Secrets können in der [offiziellen Dokumentation](https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-secrets.html) gefunden werden.
 
 ## Aufgabe: LAB8.2: Applikation an die Datenbank anbinden
 
@@ -376,7 +376,7 @@ Was enthält die hello-Tabelle?
 
 ## Aufgabe 4: Dump einspielen
 
-Die Aufgabe ist es, in den MariaDB Pod den [Dump](https://raw.githubusercontent.com/appuio/techlab/lab-4.3/labs/data/08_dump/dump.sql) einzuspielen.
+Die Aufgabe ist es, in den MariaDB Pod den [Dump](https://raw.githubusercontent.com/appuio/techlab/lab-4.x/data/08_dump/dump.sql) einzuspielen.
 
 __Tipp__:
 Mit `oc rsync` oder `oc cp` können Sie lokale Dateien in einen Pod kopieren.

--- a/labs/13_template_creation.md
+++ b/labs/13_template_creation.md
@@ -165,7 +165,7 @@ oc process -f eap70-mysql-persistent-s2i.json \
 
 ## Templates schreiben
 
-OpenShift Dokumentation: <https://docs.openshift.com/container-platform/4.3/openshift_images/using-templates.html>
+OpenShift Dokumentation: <https://docs.openshift.com/container-platform/latest/openshift_images/using-templates.html>
 
 Applikationen sollten so gebaut werden, dass sich pro Umgebung nur ein paar Konfigurationen unterscheiden.
 Diese Werte werden im Template als Parameter definiert.


### PR DESCRIPTION
Since we will always update the APPUiO techlab cluster to 4.x latest, it would be best to change all documentation links to 'latest', so we do not need to update the documentation all the time.

After merging `lab-4.x` into  `lab-4.3`, I propose we rename it to `lab-4.x`. Alternatively, we could just set branch `lab-4.x` to default and delete branch `lab-4.3`.